### PR TITLE
Fix documentation issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,10 @@ on:
       - feature/*
       - bugfix/*
       - hotfix/*
+      - docs/*
   pull_request:
     branches:
+      - main
       - develop
     types:
       - opened

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ page](https://github.com/ejpcmac/git-z/releases/latest). Just rename it to
 <summary>Click here for a detailed walkthrough for <strong>Linux</strong> and <strong>macOS</strong></summary>
 
 1. Download the executable from [the release
- page](https://github.com/ejpcmac/git-z/releases/latest).
+    page](https://github.com/ejpcmac/git-z/releases/latest).
 
 2. Move the file to a folder of you choice, rename it and make it executable.
 

--- a/README.md
+++ b/README.md
@@ -105,18 +105,21 @@ page](https://github.com/ejpcmac/git-z/releases/latest). Just rename it to
 `git-z`—or `git-z.exe` on Windows—and put it somewhere in your `PATH`.
 
 <details>
-<summary>Click here for a detailed walkthrough for <strong>Linux</strong> and <strong>macOS</strong></summary>
+<summary>
+  Click here for a detailed walkthrough for <strong>Linux</strong> and
+  <strong>macOS</strong>.
+</summary>
 
 1. Download the executable from [the release
     page](https://github.com/ejpcmac/git-z/releases/latest).
 
 2. Move the file to a folder of you choice, rename it and make it executable.
 
-    ```bash
+    ```sh
     # Create a local directory for manually installed executable files.
     mkdir -p ~/.local/bin
 
-    # Move the executable to the right directory and renane it to "git-z".
+    # Move the executable to the right directory and renane it to `git-z`.
     cd downloads
     mv git-z-0.2.3-aarch64-apple-darwin ~/.local/bin/git-z
 
@@ -126,7 +129,7 @@ page](https://github.com/ejpcmac/git-z/releases/latest). Just rename it to
 
 3. Ensure the folder in which you moved the file is referenced in your PATH.
 
-    ```bash
+    ```sh
     # Inside .bashrc, .zshrc or whatever shell config.
     PATH=$PATH:$HOME/.local/bin
     ```
@@ -136,12 +139,13 @@ page](https://github.com/ejpcmac/git-z/releases/latest). Just rename it to
     Then, you have to remove the quarantine attribute from `git-z` using the
     `xattr` command in Terminal.
 
-    ```bash
-    # Remove the quarantine on "git-z" executable.
+    ```sh
+    # Remove the quarantine attribute from the `git-z` executable.
     xattr -d com.apple.quarantine ~/.local/bin/git-z
     ```
 
-    There are also graphical ways to do it, you can refer to your system documentation.
+    There is also a graphical way to do it: you can refer to your system
+    documentation.
 
 </details>
 


### PR DESCRIPTION
The previous documentation PR broke the CI on an indentation issue. This PR fixes this issue + other slight other ones.

I’ve also cherry-picked the commit enabling the CI on `docs/*` branches and PRs to main, so that the PR properly runs before merging.