### PR TITLE
Add test coverage

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,15 @@
+codecov:
+  branch: develop
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 100%
+
+comment:
+  layout: "diff, files, components"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,30 @@ jobs:
         if: matrix.system == 'x86_64-windows'
         run: cargo xtask check test
 
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Clone the repository
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Setup the Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Setup the environment
+        run: nix build -L --no-link .#devShells.x86_64-linux.ci
+      - name: Generate the test coverage report
+        run: nix develop .#ci -c cargo xtask check coverage
+      - name: Upload the test coverage report
+        uses: codecov/codecov-action@v5
+        with:
+          disable_search: true
+          files: ./target/lcov.info
+          fail_ci_if_error: true
+          use_oidc: true
+
   unused-deps:
     name: Unused dependencies
     runs-on: ${{ matrix.runner }}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,6 +7,7 @@
         "fill-labs.dependi",
         "jnoortheen.nix-ide",
         "rust-lang.rust-analyzer",
+        "ryanluker.vscode-coverage-gutters",
         "tamasfe.even-better-toml",
         "tekumara.typos-vscode"
     ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+    "coverage-gutters.coverageBaseDir": "target",
+    "coverage-gutters.coverageReportFileName": "target/llvm-cov/html/index.html",
+    "coverage-gutters.watchOnActivate": true,
     "editor.formatOnSave": true,
     "editor.rulers": [80],
     "evenBetterToml.taplo.bundled": false,

--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 [![Crates.io License](https://img.shields.io/crates/l/git-z)](LICENSE)
 [![Conventional
 Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)
-](https://conventionalcommits.org)
+](https://conventionalcommits.org)<br>
+[![codecov](https://codecov.io/github/ejpcmac/git-z/graph/badge.svg?token=KH0AWKOBCK)](https://codecov.io/github/ejpcmac/git-z)
+[![Test Status](https://github.com/ejpcmac/git-z/actions/workflows/ci.yml/badge.svg)
+](https://github.com/ejpcmac/git-z/actions/workflows/ci.yml)
 
 A Git extension to go beyond.
 

--- a/bacon.toml
+++ b/bacon.toml
@@ -1,0 +1,80 @@
+# This is a configuration file for the bacon tool
+#
+# Complete help on configuration: https://dystroy.org/bacon/config/
+#
+# You may check the current default at
+#   https://github.com/Canop/bacon/blob/main/defaults/default-bacon.toml
+
+default_job = "clippy-all"
+env.CARGO_TERM_COLOR = "always"
+
+[jobs.check]
+command = ["cargo", "check"]
+need_stdout = false
+
+[jobs.check-all]
+command = ["cargo", "check", "--all-targets"]
+need_stdout = false
+
+[jobs.clippy]
+command = ["cargo", "clippy"]
+need_stdout = false
+
+[jobs.clippy-all]
+command = ["cargo", "clippy", "--all-targets"]
+need_stdout = false
+
+[jobs.test]
+command = ["cargo", "test"]
+need_stdout = true
+background = false
+
+[jobs.nextest]
+command = [
+    "cargo", "nextest", "run",
+    "--hide-progress-bar", "--failure-output", "final"
+]
+need_stdout = true
+background = false
+analyzer = "nextest"
+
+[jobs.coverage]
+command = [
+    "cargo", "llvm-cov", "nextest", "--branch",
+    "--lcov", "--output-path", "./target/lcov.info",
+    "--hide-progress-bar", "--failure-output", "final"
+]
+need_stdout = true
+background = false
+analyzer = "nextest"
+ignored_lines = [
+    "info: cargo-llvm-cov currently setting",
+    "warning: --branch option is unstable",
+]
+
+[jobs.coverage-report]
+command = [
+    "cargo", "llvm-cov", "nextest", "--branch", "--html",
+    "--hide-progress-bar", "--failure-output", "final"
+]
+need_stdout = true
+background = false
+analyzer = "nextest"
+ignored_lines = [
+    "info: cargo-llvm-cov currently setting",
+    "warning: --branch option is unstable",
+]
+
+[jobs.doc]
+command = ["cargo", "doc", "--no-deps"]
+need_stdout = false
+
+[jobs.doc-open]
+command = ["cargo", "doc", "--no-deps", "--open"]
+need_stdout = false
+on_success = "back"
+
+[keybindings]
+r = "job:coverage-report"
+ctrl-d = "scroll-pages(0.5)"
+ctrl-u = "scroll-pages(-0.5)"

--- a/flake.nix
+++ b/flake.nix
@@ -107,6 +107,7 @@
               ];
 
               developmentTools = with pkgs; with self'.packages; [
+                bacon
                 cargo-bloat
                 cargo-outdated
                 cargo-watch
@@ -222,6 +223,7 @@
                   (rust-bin.nightly."2025-09-24".minimal.override {
                     extensions = [ "llvm-tools" ];
                   })
+                  bacon
                   clang
                   cargo-llvm-cov
                 ];

--- a/flake.nix
+++ b/flake.nix
@@ -188,6 +188,12 @@
                         cargo llvm-cov nextest --branch --open
                     '';
                   }
+                  {
+                    name = "live-coverage";
+                    command = ''
+                      nix develop -L .#llvm-cov -c bacon coverage
+                    '';
+                  }
                 ];
               };
 

--- a/flake.nix
+++ b/flake.nix
@@ -173,6 +173,10 @@
                     command = "nix develop -L .#deb -c cargo $@";
                   }
                   {
+                    name = "cargo-llvm-cov";
+                    command = "nix develop -L .#llvm-cov -c cargo $@";
+                  }
+                  {
                     name = "cargo-udeps";
                     command = "nix develop -L .#udeps -c cargo $@";
                   }
@@ -201,6 +205,18 @@
                   })
                   clang
                   cargo-deb
+                ];
+              };
+
+              # NOTE: cargo-llvm-cov needs Rust nightly for branch coverage.
+              llvm-cov = {
+                name = "cargo-llvm-cov";
+                packages = with pkgs; [
+                  (rust-bin.nightly."2025-09-24".minimal.override {
+                    extensions = [ "llvm-tools" ];
+                  })
+                  clang
+                  cargo-llvm-cov
                 ];
               };
 

--- a/flake.nix
+++ b/flake.nix
@@ -180,6 +180,13 @@
                     name = "cargo-udeps";
                     command = "nix develop -L .#udeps -c cargo $@";
                   }
+                  {
+                    name = "coverage-report";
+                    command = ''
+                      nix develop -L .#llvm-cov -c \
+                        cargo llvm-cov nextest --branch --open
+                    '';
+                  }
                 ];
               };
 

--- a/git-z.toml
+++ b/git-z.toml
@@ -73,6 +73,7 @@ list = [
     "version",
 
     # Tools
+    "bacon",
     "cargo",
     "clippy",
     "committed",

--- a/git-z.toml
+++ b/git-z.toml
@@ -76,6 +76,7 @@ list = [
     "bacon",
     "cargo",
     "clippy",
+    "codecov",
     "committed",
     "direnv",
     "editorconfig",

--- a/taplo.toml
+++ b/taplo.toml
@@ -8,6 +8,7 @@ include = [
 
 exclude = [
     ".cargo/config.toml",
+    "bacon.toml",
     "tests/res/config/v0_1_doc-and-user-comments.toml",
     "tests/res/config/v0_1_standard.toml",
     "tests/res/config/v0_1_user-comments.toml",

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -68,6 +68,7 @@ fn check(subcommand: Option<&str>) {
             build(&mut ctx);
             check_doc(&mut ctx);
             test(&mut ctx);
+            coverage(&mut ctx);
             check_unused_deps(&mut ctx);
             check_packages(&mut ctx);
         }
@@ -76,6 +77,7 @@ fn check(subcommand: Option<&str>) {
         Some("build") => build(&mut ctx),
         Some("doc") => check_doc(&mut ctx),
         Some("test") => test(&mut ctx),
+        Some("coverage") => coverage(&mut ctx),
         Some("unused-deps") => check_unused_deps(&mut ctx),
         Some("packages") => check_packages(&mut ctx),
         _ => check_usage(),
@@ -87,7 +89,7 @@ fn check(subcommand: Option<&str>) {
 fn check_usage() {
     let name = env::args().next().unwrap();
     eprintln!(
-        "usage: {name} check [commits|format|build|doc|test|unused-deps|packages]"
+        "usage: {name} check [commits|format|build|doc|test|coverage|unused-deps|packages]"
     );
     process::exit(1);
 }
@@ -218,6 +220,28 @@ fn test(ctx: &mut Context) {
         //     "Running the doctests for all packages with all feature combinations",
         //     "cargo hack test --doc --workspace --exclude xtask --feature-powerset --keep-going",
         // ),
+    );
+}
+
+fn coverage(ctx: &mut Context) {
+    action!(
+        ctx,
+        step!(
+            "Cleaning any previous coverage report",
+            "nix develop -L .#llvm-cov -c cargo llvm-cov clean --workspace"
+        ),
+        step!(
+            "Running the tests with coverage for all packages with all feature combinations",
+            "nix develop -L .#llvm-cov -c cargo hack llvm-cov nextest --branch --no-report --workspace --exclude xtask --feature-powerset --keep-going --no-tests=warn",
+        ),
+        // step!(
+        //     "Running the doctests with coverage for all packages with all feature combinations",
+        //     "nix develop -L .#llvm-cov -c cargo hack llvm-cov test --branch --no-report --doc --workspace --exclude xtask --feature-powerset --keep-going",
+        // ),
+        step!(
+            "Generating the coverage report",
+            "nix develop -L .#llvm-cov -c cargo llvm-cov report --doctests --lcov --output-path ./target/lcov.info"
+        ),
     );
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -128,6 +128,7 @@ fn check_commits(ctx: &mut Context) {
 
 fn check_format(ctx: &mut Context) {
     let editorconfig_excluded_files = [
+        "**.json",
         "**.lock",
         "**.rs",
         "**.toml",


### PR DESCRIPTION
This PR sets test coverage up using `cargo llvm-cov` and enables reporting in Codecov.

Closes #43.